### PR TITLE
Add campo control acceso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
-## [1.4.3] - 2026-06-23 (trabajando)
+## [1.4.3] - 2026-06-29 (trabajando)
+
+### ✨ Mejoras
+
+- Se guarda el campo `codigo_acceso_url_whatsapp` en el _endpoint_ `crear_cita`. Al crear una cita nueva, se guarda los datos del sistema control de acceso.
 
 ### 🐞 Arreglado
 

--- a/pjecz_casiopea_api_oauth2/models/cit_citas.py
+++ b/pjecz_casiopea_api_oauth2/models/cit_citas.py
@@ -51,6 +51,7 @@ class CitCita(Base, UniversalMixin):
     codigo_acceso_id: Mapped[Optional[int]]
     # codigo_acceso_imagen: Mapped[Optional[bytes]] = mapped_column(BYTEA)
     codigo_acceso_url: Mapped[Optional[str]] = mapped_column(String(512))
+    codigo_acceso_url_whatsapp: Mapped[Optional[str]] = mapped_column(String(512))
     codigo_barras: Mapped[Optional[str]] = mapped_column(String(13))
     codigo_barras_url: Mapped[Optional[str]] = mapped_column(String(512))
 

--- a/pjecz_casiopea_api_oauth2/routers/cit_citas.py
+++ b/pjecz_casiopea_api_oauth2/routers/cit_citas.py
@@ -267,6 +267,9 @@ async def crear(
         codigo_acceso_url = contenido.get("imagen")
         if not codigo_acceso_url:
             return OneCitCitaOut(success=False, message="ERROR: Faltó la imagen en la respuesta de Control Acceso")
+        codigo_acceso_url_whatsapp = contenido.get("urlAcceso")
+        if not codigo_acceso_url_whatsapp:
+            return OneCitCitaOut(success=False, message="ERROR: Faltó la url de WhatsApp en la respuesta de Control Acceso")
 
         # Crear el código de barras de asistencia
         codigo_barras = CodigoBarras(database)
@@ -293,6 +296,7 @@ async def crear(
         codigo_asistencia=generar_codigo_asistencia(),
         codigo_acceso_id=codigo_acceso_id,
         codigo_acceso_url=codigo_acceso_url,
+        codigo_acceso_url_whatsapp=codigo_acceso_url_whatsapp,
         codigo_barras=codigo_barras_num,
         codigo_barras_url=codigo_barras_url,
     )


### PR DESCRIPTION
### ✨ Mejoras

- Se guarda el campo `codigo_acceso_url_whatsapp` en el _endpoint_ `crear_cita`. Al crear una cita nueva, se guarda los datos del sistema control de acceso.